### PR TITLE
Makefile target for rendered HTML notebooks and automatic GitHub Pages rendering

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,59 @@
+name: Render notebooks and push to github pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
+        with:
+          auto-activate-base: false
+          activate-environment: sealir_tester_py312
+          environment-file: conda_environment.yml
+
+      - name: Render notebooks
+        run: |
+          cd $GITHUB_WORKSPACE/numba-prototypes/sealir-tutorials
+          make pages
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: $GITHUB_WORKSPACE/numba-prototypes/sealir-tutorials/pages
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.so
 *.pyc
 __pycache__
+pages/**
+.ipynb_checkpoints

--- a/sealir-tutorials/Makefile
+++ b/sealir-tutorials/Makefile
@@ -2,13 +2,15 @@
 # -----
 #
 # Initialize the notebooks with `make all`.
-# Any update to the `.py` or `*.ipynb` files can be 
-# synchronized by `make sync`. Synchronization works both ways, 
+# Any update to the `.py` or `*.ipynb` files can be
+# synchronized by `make sync`. Synchronization works both ways,
 # edits on .ipynb will reflect in paired .py, and vice-versa.
 
 # Define source directory and output directory
 PY_FILES := $(wildcard *.py)
 IPYNB_FILES := $(patsubst %.py,%.ipynb,$(PY_FILES))
+PAGES_SUBDIR := ../pages/sealir_tutorials
+HTML_FILES := $(patsubst %.ipynb,$(PAGES_SUBDIR)/%.html,$(IPYNB_FILES))
 
 # Default target to build all notebooks
 all: $(IPYNB_FILES)
@@ -22,9 +24,18 @@ format:
 	isort -l79 --profile black .
 	black -l79 .
 
+pages: $(HTML_FILES)
+
+$(PAGES_SUBDIR):
+	mkdir -p $(PAGES_SUBDIR)
+
 # Pattern rule to convert .py files to .ipynb
 %.ipynb: %.py
 	jupytext --update --to ipynb --from py:light $< -o $@
+
+# Pattern rule to convert .ipynb files to rendered .html
+$(PAGES_SUBDIR)/%.html: %.ipynb $(PAGES_SUBDIR)
+	jupyter nbconvert --to html --output=$@ $<
 
 # Clean target to remove generated notebooks
 clean:

--- a/sealir-tutorials/README.md
+++ b/sealir-tutorials/README.md
@@ -28,7 +28,7 @@ Run `make all` to initialize `*.ipynb` files.
 It can be easier to edit the markdown in `.ipynb` via visual editors.
 Edits can be synchronized to the paired py-ipynb files by `make sync`
 
-Run `make format` to use `black` and `isort` to auto-format the scripts. 
+Run `make format` to use `black` and `isort` to auto-format the scripts.
 
 To remove the `*.ipynb` files, run `make clean`.
 
@@ -38,3 +38,10 @@ To remove the `*.ipynb` files, run `make clean`.
 Tests are located in `./tests` directory.
 
 Use `pytest` to run all tests.
+
+## Rendering notebooks to HTML
+
+Run `make pages` to render the notebooks to HTML for export to GitHub pages.
+Output will be in the `../pages/sealir-tutorials` subdirectory.  Remember to keep
+the Markdown table of contents in `index.py` file up-to-date when new notebooks
+are added.

--- a/sealir-tutorials/index.py
+++ b/sealir-tutorials/index.py
@@ -1,0 +1,39 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.7
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# # Numba v2 Compiler Design <img src="https://numba.pydata.org/_static/numba-blue-icon-rgb.svg" width="80" style="float:right;"/> 
+#
+# This book describes the compiler design of the next generation Numba compiler.  This compiler and its components are *extremely experimental* and under rapid development.  If you have questions, [raise an issue](https://github.com/numba/numba-prototypes/issues) on the GitHub repository.
+#
+# ## Chapters
+#
+# * [Chapter 1 - Basic Compiler Design](ch01_basic_compiler.html)
+# * [Chapter 2 - EGraph Basics](ch02_egraph_basic.html)
+# * [Chapter 3 - Rewriting Programs with EGraphs](ch03_egraph_program_rewrites.html)
+# * Chapter 4 - Scalar Type Inference with EGraphs
+# * Chapter 5 - Array Type Inference with EGraphs
+# * Chapter 6 - MLIR Backend for Scalar Functions
+# * Chapter 7 - MLIR Backend for Array Functions
+# * Chapter 8 - MLIR Backend for Array Offload to the GPU
+# * Chapter 9 - Whole Program Compiler Driver
+# * Chapter 10 - Tensor Graph Extraction
+# * Chapter 11 - Tensor Optimization
+# * Chapter 12 - Implementing Alternative GEMMS
+#
+# ## Demos
+# * Demo 1: GEGLU Tanh Approximation
+# * Demo 2: GPU Offload
+# * Demo 3: TENSAT Array Expression Rewrite
+# * Demo 4: Energy Efficient GEMMs
+#


### PR DESCRIPTION
Automate generating a browsable version of the tutorial:

* `make pages` now renders the notebooks to HTML using nbconvert.  
* There's an Jupytext format `index.py` file, which exists just to provide a table of contents for the rest of the notebooks
* GitHub Actions workflow to render the pages and deploy them after every commit to main, or manually.
