### PR TITLE
Simplified cost for demo1 

### DIFF
--- a/sealir-tutorials/ch04_0_typeinfer_prelude.py
+++ b/sealir-tutorials/ch04_0_typeinfer_prelude.py
@@ -312,7 +312,7 @@ def codegen_extension(expr, args, builder, pyapi):
 
 
 class MyCostModel(CostModel):
-    def get_cost_function(self, nodename, op, ty, cost, nodes, child_costs):
+    def get_cost_function(self, nodename, op, ty, cost, children):
         self_cost = None
         match op:
             case "Nb_Unboxed_Add_Int64":
@@ -325,12 +325,10 @@ class MyCostModel(CostModel):
                 self_cost = 0.1
 
         if self_cost is not None:
-            return self_cost + sum(child_costs)
+            return self.get_simple(self_cost)
 
         # Fallthrough to parent's cost function
-        return super().get_cost_function(
-            nodename, op, ty, cost, nodes, child_costs
-        )
+        return super().get_cost_function(nodename, op, ty, cost, children)
 
 
 # The new ruleset with the type inference logic and facts about the compiled

--- a/sealir-tutorials/ch04_1_typeinfer_ifelse.py
+++ b/sealir-tutorials/ch04_1_typeinfer_ifelse.py
@@ -946,16 +946,17 @@ class ExtendEGraphToRVSDG(EGraphToRVSDG):
 
 
 class MyCostModel(CostModel):
-    def get_cost_function(self, nodename, op, ty, cost, nodes, child_costs):
-        if op.startswith("Py_"):
+    def get_cost_function(self, nodename, op, ty, cost, children):
+        if "Term.Literal" in op:
+            # Literals has very low cost
+            return self.get_simple(1)
+        elif op.startswith("Py_"):
             # Penalize Python operations
-            # return float("inf")
-            return float(1e9999)
-
+            return self.get_simple(float("inf"))
+        elif op.startswith("Nb_"):
+            return self.get_simple(cost)
         # Fallthrough to parent's cost function
-        return super().get_cost_function(
-            nodename, op, ty, cost, nodes, child_costs
-        )
+        return super().get_cost_function(nodename, op, ty, cost, children)
 
 
 # + [markdown] jp-MarkdownHeadingCollapsed=true

--- a/sealir-tutorials/demo01_gelu_tanh_approx.py
+++ b/sealir-tutorials/demo01_gelu_tanh_approx.py
@@ -424,21 +424,19 @@ class Backend(ch06_Backend):
 
 
 class MyCostModel(ch06_CostModel):
-    def get_cost_function(self, nodename, op, ty, cost, nodes, child_costs):
+    def get_cost_function(self, nodename, op, ty, cost, children):
         match op:
             case "Npy_tanh" | "Npy_sqrt" | "Npy_float32":
                 cost = float("inf")  # suppress untyped op
             case "Npy_tanh_float32":
-                cost = 1000
+                cost = 100
             case "Npy_sqrt_float32":
-                cost = 10
+                cost = 50
             case "Nb_Pow_Float32_Int64":
-                cost = 1000  # FIXME caused by a bug in cost-extraction
+                cost = 50
 
         # Fallthrough to parent's cost function
-        return super().get_cost_function(
-            nodename, op, ty, cost, nodes, child_costs
-        )
+        return super().get_cost_function(nodename, op, ty, cost, children)
 
 
 # ### Run the baseline function

--- a/sealir-tutorials/tests/test_ch04_0.py
+++ b/sealir-tutorials/tests/test_ch04_0.py
@@ -16,7 +16,10 @@ def check(fn, ruleset):
     egraph.run(ruleset.saturate())
 
     cost, extracted = egraph_extraction(
-        egraph, rvsdg_expr, converter_class=ExtendEGraphToRVSDG
+        egraph,
+        rvsdg_expr,
+        converter_class=ExtendEGraphToRVSDG,
+        cost_model=MyCostModel(),
     )
     return extracted
 


### PR DESCRIPTION
depends on https://github.com/numba/sealir/pull/8

Changes:

- `CostModel.get_cost_function()` is changed in SealIR to return a `CostFunc` object
- Cost calculation is more intuitive now. We can avoid artificially inflating cost as a heuristic to nudge the cost-based extraction. 