### PR TITLE
fix pages deployment

### DIFF
--- a/sealir-tutorials/conda_environment.yml
+++ b/sealir-tutorials/conda_environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytest
   - networkx
   - numpy
+  - numba
   - nbconvert
   - ipykernel
   - jupyter


### PR DESCRIPTION
The chapter `ch08_gpu_offload` requires the `numba` package.

Currently deployment of the pages fails with:

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[3], line 6
      4 import mlir.runtime as runtime
      5 import numpy as np
----> 6 from numba import cuda

ModuleNotFoundError: No module named 'numba'

make: *** [Makefile:38: ../pages/sealir_tutorials/ch08_gpu_offload.html] Error 1
```