### PR TITLE
add pygraphviz to fix pages deployment

### DIFF
--- a/sealir-tutorials/conda_environment.yml
+++ b/sealir-tutorials/conda_environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - jupytext
   - make
   - graphviz
+  - pygraphviz
   - pip
   - pip:
     - egglog


### PR DESCRIPTION
chp09 needs `pygraphviz` on notebook 

```
------------------
if IN_NOTEBOOK:
    IPython.display.display(to_graphviz(cgv))
------------------


---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
File /usr/share/miniconda/envs/sealir_tutorial/lib/python3.12/site-packages/networkx/drawing/nx_agraph.py:134, in to_agraph(N)
    133 try:
--> 134     import pygraphviz
    135 except ImportError as err:

ModuleNotFoundError: No module named 'pygraphviz'

The above exception was the direct cause of the following exception:

ImportError                               Traceback (most recent call last)
Cell In[10], line 2
      1 if IN_NOTEBOOK:
----> 2     IPython.display.display(to_graphviz(cgv)) 
```