### PR TITLE
add graphviz-dev to get system lib - libcgraph.so.6

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,11 @@ jobs:
           activate-environment: sealir_tutorial
           environment-file: sealir-tutorials/conda_environment.yml
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz-dev
+
       - name: Render notebooks
         run: |
           source $CONDA/bin/activate


### PR DESCRIPTION
this to fix system lib error on ubuntu gha runner -
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
File /usr/share/miniconda/envs/sealir_tutorial/lib/python3.12/site-packages/networkx/drawing/nx_agraph.py:134, in to_agraph(N)
    133 try:
--> 134     import pygraphviz
    135 except ImportError as err:

File /usr/share/miniconda/envs/sealir_tutorial/lib/python3.12/site-packages/pygraphviz/__init__.py:24
     22 __version__ = "1.14"
---> 24 from .agraph import AGraph, Node, Edge, Attribute, ItemAttribute, DotError
     26 __all__ = ["AGraph", "Node", "Edge", "Attribute", "ItemAttribute", "DotError"]

File /usr/share/miniconda/envs/sealir_tutorial/lib/python3.12/site-packages/pygraphviz/agraph.py:17
     15 import pathlib
---> 17 from . import graphviz as gv
     18 import contextlib

File /usr/share/miniconda/envs/sealir_tutorial/lib/python3.12/site-packages/pygraphviz/graphviz.py:10
      9 if __package__ or "." in __name__:
---> 10     from . import _graphviz
     11 else:

ImportError: libcgraph.so.6: cannot open shared object file: No such file or directory
```