### PR TITLE
Apply updates used in scipy2025 slides

### DIFF
--- a/sealir-tutorials/Makefile
+++ b/sealir-tutorials/Makefile
@@ -10,8 +10,11 @@
 PY_FILES := $(wildcard ch[0-9]*.py) $(wildcard demo[0-9]*.py) index.py
 IPYNB_FILES := $(patsubst %.py,%.ipynb,$(PY_FILES))
 PAGES_SUBDIR := ../pages/sealir_tutorials
-PRE_RENDERED_HTML_FILES := $(wildcard *.pre_rendered.html)
-HTML_FILES := $(patsubst %.ipynb,$(PAGES_SUBDIR)/%.html,$(IPYNB_FILES)) $(patsubst %.pre_rendered.html,$(PAGES_SUBDIR)/%.pre_rendered.html,$(PRE_RENDERED_HTML_FILES))
+HTML_FILES := $(patsubst %.ipynb,$(PAGES_SUBDIR)/%.html,$(IPYNB_FILES))
+IMG_DIR := ./img
+IMG_TARGET_DIR := $(PAGES_SUBDIR)/img
+IMG_FILES := $(wildcard $(IMG_DIR)/*)
+IMG_TARGET_FILES := $(patsubst $(IMG_DIR)/%,$(IMG_TARGET_DIR)/%,$(IMG_FILES))
 
 # Default target to build all notebooks
 all: $(IPYNB_FILES)
@@ -30,10 +33,22 @@ format:
 		echo "$$files" | xargs black -l79; \
 	fi
 
-pages: $(PAGES_SUBDIR) $(HTML_FILES)
+pages: $(PAGES_SUBDIR) $(HTML_FILES) $(IMG_TARGET_FILES)
 
 $(PAGES_SUBDIR):
 	mkdir -p $(PAGES_SUBDIR)
+
+# Create target directory for images
+$(IMG_TARGET_DIR):
+	mkdir -p $(IMG_TARGET_DIR)
+
+# Pattern rule to copy individual image files when they change
+$(IMG_TARGET_DIR)/%: $(IMG_DIR)/% | $(IMG_TARGET_DIR)
+	@echo "Copying $< to $@"
+	cp $< $@
+
+# Convenience target for copying all images
+copy-img: $(IMG_TARGET_FILES)
 
 # Pattern rule to convert .py files to .ipynb
 %.ipynb: %.py
@@ -43,14 +58,12 @@ $(PAGES_SUBDIR):
 $(PAGES_SUBDIR)/%.html: %.ipynb
 	jupyter nbconvert --execute --to html  --HTMLExporter.theme=dark --output=$@ $<
 
-# Pattern rule to copy pre-rendered .html files
-$(PAGES_SUBDIR)/%.pre_rendered.html: %.pre_rendered.html
-	cp $< $@
-
 # Clean target to remove generated notebooks and rendered HTML
 clean:
 	rm -f $(IPYNB_FILES)
 	rm -f $(HTML_FILES)
+	rm -f $(IMG_TARGET_FILES)
+	rm -rf $(IMG_TARGET_DIR)
 	rm -df $(PAGES_SUBDIR)
 
 test:

--- a/sealir-tutorials/ch03_egraph_program_rewrites.py
+++ b/sealir-tutorials/ch03_egraph_program_rewrites.py
@@ -57,9 +57,10 @@ def egraph_saturation(
     pipeline_report=Report.Sink(),
 ) -> EGraphOutput:
     # Apply the ruleset to the egraph
-    egraph.run(ruleset.saturate())
-    pipeline_report.append("EGraph Saturated", egraph)
-    return {"egraph": egraph, "egraph_root": egraph_root}
+    with pipeline_report.nest("Egraph Saturation") as report:
+        runreport = egraph.run(ruleset.saturate())
+        report.append("egraph run report", runreport)
+        return {"egraph": egraph, "egraph_root": egraph_root}
 
 
 compiler_pipeline = _ch02_compiler_pipeline.replace(

--- a/sealir-tutorials/ch04_1_typeinfer_ifelse.py
+++ b/sealir-tutorials/ch04_1_typeinfer_ifelse.py
@@ -521,9 +521,10 @@ def egraph_saturation_with_error_checking(
             report.append("[debug] initial egraph", egraph)
 
         # Run all the rules until saturation
-        egraph.run(ruleset.saturate())
+        runreport = egraph.run(ruleset.saturate())
 
         if pipeline_debug:
+            report.append("[debug] run report", runreport)
             report.append("[debug] saturated egraph", egraph)
             report.append(
                 "[debug] egglog.extract", egraph.extract(egraph_root)

--- a/sealir-tutorials/ch04_2_typeinfer_loops.py
+++ b/sealir-tutorials/ch04_2_typeinfer_loops.py
@@ -81,6 +81,7 @@ from ch04_1_typeinfer_ifelse import (
     ruleset_type_infer_float,
     setup_argtypes,
 )
+from utils import Report
 
 # ## Loop Type Inference Rules
 #
@@ -322,9 +323,11 @@ if __name__ == "__main__":
         fn=example_1,
         argtypes=(Int64, Int64),
         ruleset=base_ruleset | setup_argtypes(TypeInt64, TypeInt64),
+        pipeline_report=Report(),
         **compiler_config,
     )
     jit_func = cres.jit_func
+    cres.pipeline_report.display()
     run_test(example_1, jit_func, (10, 7), verbose=True)
 
 # ## Example 2: Nested Loop

--- a/sealir-tutorials/demo01_gelu_tanh_approx.py
+++ b/sealir-tutorials/demo01_gelu_tanh_approx.py
@@ -95,7 +95,7 @@ from ch07_mlir_ufunc import (
     ufunc_compiler,
     ufunc_vectorize,
 )
-from utils.report import Report
+from utils import Report, timeit, visualize_benchmark
 
 # ## The GELU Function
 #
@@ -618,6 +618,14 @@ if __name__ == "__main__":
     out = np.zeros_like(input_val)
 
     print("original")
-    # %timeit gelu_tanh_forward(input_val)
+    t_original = timeit(lambda: gelu_tanh_forward(input_val))
+
     print("superoptimized")
-    # %timeit vectorized_gelu(input_val, out=out)
+    t_superopt = timeit(lambda: vectorized_gelu(input_val, out=out))
+
+    visualize_benchmark(
+        t_original,
+        t_superopt,
+        labels=["original", "superoptimized"],
+        title="GELU Ufunc Benchmark",
+    )

--- a/sealir-tutorials/demo03_0_matmul_assoc.py
+++ b/sealir-tutorials/demo03_0_matmul_assoc.py
@@ -286,9 +286,10 @@ def egraph_saturation(
                 ).to_json()
                 saturation_steps.append(jsdata)
         else:
-            egraph.run(all_rules.saturate())
+            runreport = egraph.run(all_rules.saturate())
             saturation_steps = None
         if pipeline_debug:
+            report.append("[debug] Run report", runreport)
             report.append("[debug] Saturated egraph", egraph)
         return dict(egraph=egraph, saturation_steps=saturation_steps)
 

--- a/sealir-tutorials/demo03_0_matmul_assoc.py
+++ b/sealir-tutorials/demo03_0_matmul_assoc.py
@@ -77,7 +77,13 @@ from ch05_typeinfer_array import (
     base_ruleset,
     setup_argtypes,
 )
-from utils import Pipeline, Report, display, visualize_expr_tree
+from utils import (
+    Report,
+    display,
+    timeit,
+    visualize_benchmark,
+    visualize_expr_tree,
+)
 
 # -
 
@@ -95,24 +101,52 @@ K = 200
 
 # (M x N) (N x K) (K x N)
 
+f0_3m = lambda arr0, arr1, arr2: (arr0 @ arr1) @ arr2
+f1_3m = lambda arr0, arr1, arr2: arr0 @ (arr1 @ arr2)
+
+# <img src="img/matmul_assoc.svg" width="80%" />
+
+# compute cost as FLOPS
+
+if __name__ == "__main__":
+    print(" left associative cost =", (2 * M * N * K) * (2 * M * K * K))
+    print("right associative cost =", (2 * N * K * N) * (2 * M * N * N))
+
+    report = Report("expr tree", True)
+    report.append("f0_3m", visualize_expr_tree(f0_3m))
+    report.append("f1_3m", visualize_expr_tree(f1_3m))
+    report.display()
+
+
 if __name__ == "__main__":
     arr0 = np.random.random((M, N))
     arr1 = np.random.random((N, K))
     arr2 = np.random.random((K, N))
-    res0 = (arr0 @ arr1) @ arr2
-    res1 = arr0 @ (arr1 @ arr2)
-    print(res0.shape)
-    print(res1.shape)
-    np.testing.assert_allclose(res0, res1)
+    print(arr0.shape, arr1.shape, arr2.shape)
+    res0 = f0_3m(arr0, arr1, arr2)
+    res1 = f1_3m(arr0, arr1, arr2)
     # unoptimized
-    # %timeit arr0 @ arr1 @ arr2
+    left_time = timeit(lambda: f0_3m(arr0, arr1, arr2))
     # optimized
-    # %timeit arr0 @ (arr1 @ arr2)
+    right_time = timeit(lambda: f1_3m(arr0, arr1, arr2))
+
+    visualize_benchmark(
+        left_time,
+        right_time,
+        labels=["Left-associative", "Right-associative"],
+        title="Matrix Multiplication Optimization",
+        figsize=(8, 5),
+    )
 
 # ## NumPy Example: Five Matrix Multiplications
 #
-# Here we define two different ways to multiply five matrices and compare their
+# Here we define two different ways to do five matrix multiplications and compare their
 # results and performance.
+# <code>
+# arr0 @ arr1 @ arr2 @ arr1 @ arr2 @ arr3
+#        ^^^^^^^^^^^   ^^^^^^^^^^^
+#           common subexpressions
+# </code>
 
 f0 = lambda arr0, arr1, arr2, arr3: arr0 @ arr1 @ arr2 @ arr1 @ arr2 @ arr3
 
@@ -140,9 +174,16 @@ if __name__ == "__main__":
     report.display()
 
     # unoptimized
-    # %timeit f0(arr0, arr1, arr2, arr3)
+    f0_time = timeit(lambda: f0(arr0, arr1, arr2, arr3))
     # optimized
-    # %timeit f1(arr0, arr1, arr2, arr3)
+    f1_time = timeit(lambda: f1(arr0, arr1, arr2, arr3))
+    visualize_benchmark(
+        f0_time,
+        f1_time,
+        labels=["original", "hand-optimized"],
+        title="Matrix Multiplication Optimization",
+        figsize=(8, 5),
+    )
 
 # ## E-Graph Construction for Matrix Multiplication
 #
@@ -180,6 +221,21 @@ def MatMul_KnownShape(
 def ArrayDescOp(term: Term) -> ArrayDesc: ...
 
 
+# ### Matrix Multiplication Associativity
+
+
+@ruleset
+def ruleset_matmul_associativity(
+    ary0: Term,
+    ary1: Term,
+    ary2: Term,
+):
+    # associative
+    yield rewrite(MatMul(MatMul(ary0, ary1), ary2)).to(
+        MatMul(ary0, MatMul(ary1, ary2))
+    )
+
+
 @ruleset
 def ruleset_optimize_matmul(
     ary0: Term,
@@ -191,11 +247,6 @@ def ruleset_optimize_matmul(
     shapeN: i64,
     shapeK: i64,
 ):
-    # associative
-    yield rewrite(MatMul(MatMul(ary0, ary1), ary2)).to(
-        MatMul(ary0, MatMul(ary1, ary2))
-    )
-
     yield rule(
         # array desc propagation
         ary2 == MatMul(ary0, ary1),
@@ -287,9 +338,11 @@ def egraph_saturation(
                 saturation_steps.append(jsdata)
         else:
             runreport = egraph.run(all_rules.saturate())
+            if pipeline_debug:
+                report.append("[debug] Run report", runreport)
             saturation_steps = None
+
         if pipeline_debug:
-            report.append("[debug] Run report", runreport)
             report.append("[debug] Saturated egraph", egraph)
         return dict(egraph=egraph, saturation_steps=saturation_steps)
 
@@ -299,7 +352,9 @@ pipeline_middle_end = _ch04_0_pipeline_new_extract.trunc(
 ).replace("egraph_saturation", egraph_saturation)
 pipeline_to_egraph = pipeline_middle_end.trunc("pipeline_egraph_extraction")
 
-extra_ruleset = ruleset_matmul_op | ruleset_optimize_matmul
+extra_ruleset = (
+    ruleset_matmul_op | ruleset_optimize_matmul | ruleset_matmul_associativity
+)
 
 
 if __name__ == "__main__":
@@ -488,6 +543,9 @@ if __name__ == "__main__":
     res0 = f1(arr0, arr1, arr2, arr3)
     np.testing.assert_allclose(res0, res1)
 
+# ### Benchmark
+
+if __name__ == "__main__":
     report = Report(
         "Expression tree of different versions",
         default_expanded=True,
@@ -500,10 +558,19 @@ if __name__ == "__main__":
     report.display()
 
     # original
-    # %timeit f0(arr0, arr1, arr2, arr3)
+    f0_time = timeit(lambda: f0(arr0, arr1, arr2, arr3))
 
     # manual optimized
-    # %timeit f1(arr0, arr1, arr2, arr3)
+    f1_time = timeit(lambda: f1(arr0, arr1, arr2, arr3))
 
     # cost-based extraction
-    # %timeit extracted(arr0, arr1, arr2, arr3)
+    superopt_time = timeit(lambda: extracted(arr0, arr1, arr2, arr3))
+
+    visualize_benchmark(
+        f0_time,
+        f1_time,
+        superopt_time,
+        labels=["original", "hand-optimized", "superoptimized"],
+        title="Matrix Multiplication Optimization",
+        figsize=(8, 5),
+    )

--- a/sealir-tutorials/demo03_1_tensor_optimization.py
+++ b/sealir-tutorials/demo03_1_tensor_optimization.py
@@ -112,12 +112,17 @@ from utils import (
 # Two separate matmuls followed by elementwise add
 
 
+# <img src="img/matmul_add.svg" />
+
+
 def original_mma(input_1, input_2, input_3, input_4):
     return input_1 @ (input_2 + input_3) @ input_4
 
 
 # ### Optimized version
 # Concatenate inputs along feature dimensions
+#
+# <img src="img/hstack_vstack.svg" />
 
 
 def optimized_mma(input_1, input_2, input_3, input_4):

--- a/sealir-tutorials/demo03_1_tensor_optimization.py
+++ b/sealir-tutorials/demo03_1_tensor_optimization.py
@@ -91,10 +91,17 @@ from demo03_0_matmul_assoc import SourceMaker as _demo03_0_SourceMaker
 from demo03_0_matmul_assoc import (
     compiler,
     pipeline_to_egraph,
+    ruleset_matmul_associativity,
     ruleset_matmul_op,
     ruleset_optimize_matmul,
 )
-from utils import Pipeline, Report, display, visualize_expr_tree
+from utils import (
+    Report,
+    display,
+    timeit,
+    visualize_benchmark,
+    visualize_expr_tree,
+)
 
 # ## Original and Optimized Matrix Multiplication Functions
 #
@@ -114,9 +121,9 @@ def original_mma(input_1, input_2, input_3, input_4):
 
 
 def optimized_mma(input_1, input_2, input_3, input_4):
-    #    input_1 @ (input_2, input_3)
+    #    input_1 @ (input_2 + input_3)
     # => input_1 @ input_2 + input_1 @ input_3
-    # => hstack(input_1, input_1) + vstack(input_2, input_3)
+    # => hstack(input_1, input_1) @ vstack(input_2, input_3)
     concat_input = np.hstack([input_1, input_1])
     concat_weight = np.vstack([input_2, input_3])
     return concat_input @ concat_weight @ input_4
@@ -219,8 +226,8 @@ def ruleset_tensat(ary1: Term, ary2: Term, ary3: Term, ary4: Term):
     matmul = Npy_MatMul
     hstack = Npy_HStack
     vstack = Npy_VStack
-    # tensat rule
-    # (A @ B) + (C @ D) => (A, C) @ (B, D)
+    # taso/tensat rule
+    # (A @ B) + (C @ D) => hstack(A, C) @ vstack(B, D)
     yield rewrite(
         ewadd(matmul(ary1, ary3), matmul(ary2, ary4)),
     ).to(matmul(hstack(ary1, ary2), vstack(ary3, ary4)))
@@ -498,6 +505,7 @@ extra_ruleset = (
     | ruleset_broadcasting
     | ruleset_matmul_op
     | ruleset_optimize_matmul
+    | ruleset_matmul_associativity
     | ruleset_tensat
     | ruleset_specialize_numpy
 )
@@ -534,7 +542,6 @@ if __name__ == "__main__":
         extra_ruleset=extra_ruleset,
         arg_facts=ruleset_array_facts,
         global_ns={"np": np},
-        animate=True,
         pipeline_report=report,
         pipeline_debug=True,
         cost_model=MyCostModel(),
@@ -552,17 +559,26 @@ if __name__ == "__main__":
 
     extracted = cres.extracted
 
-    import json
-
-    steps = []
-    for step in cres.saturation_steps:
-        steps.append(json.loads(step))
-    with open("jsanimate.json", "w") as fout:
-        json.dump({"steps": steps}, fout)
-
     got = extracted(input_1, input_2, input_3, input_4)
     np.testing.assert_allclose(original, got)
 
-    # %timeit original_mma(input_1, input_2, input_3, input_4)
-    # %timeit optimized_mma(input_1, input_2, input_3, input_4)
-    # %timeit extracted(input_1, input_2, input_3, input_4)
+    print("original")
+    t_original = timeit(
+        lambda: original_mma(input_1, input_2, input_3, input_4)
+    )
+
+    print("hand-optimzed")
+    t_handopt = timeit(
+        lambda: optimized_mma(input_1, input_2, input_3, input_4)
+    )
+
+    print("superoptimized")
+    t_superopt = timeit(lambda: extracted(input_1, input_2, input_3, input_4))
+
+    visualize_benchmark(
+        t_original,
+        t_handopt,
+        t_superopt,
+        labels=["original", "hand-optimized", "superoptimized"],
+        title="Tensor Algebra Optimization",
+    )

--- a/sealir-tutorials/img/hstack_vstack.svg
+++ b/sealir-tutorials/img/hstack_vstack.svg
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 1002 270.35217"
+   version="1.1"
+   id="svg42"
+   sodipodi:docname="hstack_vstack.svg"
+   width="1002"
+   height="270.35217"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview42"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.4737011"
+     inkscape:cx="354.8888"
+     inkscape:cy="125.195"
+     inkscape:window-width="1520"
+     inkscape:window-height="1186"
+     inkscape:window-x="1048"
+     inkscape:window-y="43"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g28" />
+  <!-- Background -->
+  <rect
+     width="1000.3605"
+     height="268.71265"
+     fill="#f8f9fa"
+     stroke="#e9ecef"
+     stroke-width="1.63954"
+     id="rect1"
+     style="fill:#ececec"
+     x="0.81976998"
+     y="0.81976998" />
+  <!-- Title -->
+  <text
+     x="501"
+     y="31"
+     text-anchor="middle"
+     font-family="Times, serif"
+     font-size="20px"
+     font-weight="bold"
+     fill="#2c3e50"
+     id="text1"
+     dx="0 0 0 0 0 0">Tensor rewrite rule: A @ B + C @ D = hstack(A, C) @ vstack(B, D)</text>
+  <!-- Left side: A @ B + C @ D -->
+  <g
+     transform="translate(50.999999,80.999999)"
+     id="g15">
+    <text
+       x="0"
+       y="20"
+       font-family="Times, serif"
+       font-size="16px"
+       font-weight="bold"
+       fill="#2c3e50"
+       id="text2">Original Expression:</text>
+    <!-- A @ B -->
+    <g
+       transform="translate(0,50)"
+       id="g8">
+      <!-- Matrix A -->
+      <g
+         id="g4">
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="40"
+           fill="#e3f2fd"
+           stroke="#1976d2"
+           stroke-width="2"
+           id="rect2" />
+        <text
+           x="30"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#1976d2"
+           id="text3">A</text>
+        <text
+           x="30"
+           y="55"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="12px"
+           fill="#666666"
+           id="text4">M × N</text>
+      </g>
+      <!-- @ symbol -->
+      <text
+         x="75"
+         y="25"
+         font-family="Times, serif"
+         font-size="16px"
+         fill="#2c3e50"
+         id="text5">@</text>
+      <!-- Matrix B -->
+      <g
+         transform="translate(95)"
+         id="g7">
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="40"
+           fill="#e8f5e8"
+           stroke="#388e3c"
+           stroke-width="2"
+           id="rect5" />
+        <text
+           x="30"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#388e3c"
+           id="text6">B</text>
+        <text
+           x="30"
+           y="55"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="12px"
+           fill="#666666"
+           id="text7">N × K</text>
+      </g>
+    </g>
+    <!-- + symbol -->
+    <text
+       x="185"
+       y="75"
+       font-family="Times, serif"
+       font-size="20px"
+       fill="#2c3e50"
+       id="text8">+</text>
+    <!-- C @ D -->
+    <g
+       transform="translate(220,50)"
+       id="g14">
+      <!-- Matrix C -->
+      <g
+         id="g10">
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="40"
+           fill="#fce4ec"
+           stroke="#c2185b"
+           stroke-width="2"
+           id="rect8" />
+        <text
+           x="30"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#c2185b"
+           id="text9">C</text>
+        <text
+           x="30"
+           y="55"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="12px"
+           fill="#666666"
+           id="text10">M × P</text>
+      </g>
+      <!-- @ symbol -->
+      <text
+         x="75"
+         y="25"
+         font-family="Times, serif"
+         font-size="16px"
+         fill="#2c3e50"
+         id="text11">@</text>
+      <!-- Matrix D -->
+      <g
+         transform="translate(95)"
+         id="g13">
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="40"
+           fill="#fff3e0"
+           stroke="#f57c00"
+           stroke-width="2"
+           id="rect11" />
+        <text
+           x="30"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#f57c00"
+           id="text12">D</text>
+        <text
+           x="30"
+           y="55"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="12px"
+           fill="#666666"
+           id="text13">P × K</text>
+      </g>
+    </g>
+  </g>
+  <!-- Equals symbol -->
+  <text
+     x="501"
+     y="141"
+     text-anchor="middle"
+     font-family="Times, serif"
+     font-size="24px"
+     fill="#2c3e50"
+     id="text15">=</text>
+  <!-- Right side: hstack(A, C) @ vstack(B, D) -->
+  <g
+     transform="translate(551,80.999999)"
+     id="g27">
+    <text
+       x="0"
+       y="20"
+       font-family="Times, serif"
+       font-size="16px"
+       font-weight="bold"
+       fill="#2c3e50"
+       id="text16">Equivalent Expression:</text>
+    <!-- hstack(A, C) -->
+    <g
+       transform="translate(0,50)"
+       id="g21">
+      <text
+         x="0"
+         y="15"
+         font-family="Times, serif"
+         font-size="14px"
+         fill="#666666"
+         id="text17">hstack(A, C)</text>
+      <!-- Combined matrix [A | C] -->
+      <g
+         transform="translate(0,20)"
+         id="g20">
+        <rect
+           x="0"
+           y="0"
+           width="120"
+           height="40"
+           fill="#f3e5f5"
+           stroke="#7b1fa2"
+           stroke-width="2"
+           id="rect17" />
+        <!-- A section -->
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="40"
+           fill="#e3f2fd"
+           stroke="#1976d2"
+           stroke-width="2"
+           id="rect18" />
+        <text
+           x="30"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#1976d2"
+           id="text18">A</text>
+        <!-- C section -->
+        <rect
+           x="60"
+           y="0"
+           width="60"
+           height="40"
+           fill="#fce4ec"
+           stroke="#c2185b"
+           stroke-width="2"
+           id="rect19" />
+        <text
+           x="90"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#c2185b"
+           id="text19">C</text>
+        <!-- Combined dimension -->
+        <text
+           x="60"
+           y="55"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="12px"
+           fill="#666666"
+           id="text20">M × (N+P)</text>
+      </g>
+    </g>
+    <!-- @ symbol -->
+    <text
+       x="140"
+       y="85"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text21">@</text>
+    <!-- vstack(B, D) -->
+    <g
+       transform="translate(160,50)"
+       id="g26">
+      <text
+         x="0"
+         y="15"
+         font-family="Times, serif"
+         font-size="14px"
+         fill="#666666"
+         id="text22">vstack(B, D)</text>
+      <!-- Combined matrix [B; D] -->
+      <g
+         transform="translate(0,20)"
+         id="g25">
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="80"
+           fill="#f3e5f5"
+           stroke="#7b1fa2"
+           stroke-width="2"
+           id="rect22" />
+        <!-- B section -->
+        <rect
+           x="0"
+           y="0"
+           width="60"
+           height="40"
+           fill="#e8f5e8"
+           stroke="#388e3c"
+           stroke-width="2"
+           id="rect23" />
+        <text
+           x="30"
+           y="25"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#388e3c"
+           id="text23">B</text>
+        <!-- D section -->
+        <rect
+           x="0"
+           y="40"
+           width="60"
+           height="40"
+           fill="#fff3e0"
+           stroke="#f57c00"
+           stroke-width="2"
+           id="rect24" />
+        <text
+           x="30"
+           y="65"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="14px"
+           font-weight="bold"
+           fill="#f57c00"
+           id="text24">D</text>
+        <!-- Combined dimension -->
+        <text
+           x="30"
+           y="93"
+           text-anchor="middle"
+           font-family="Times, serif"
+           font-size="12px"
+           fill="#666666"
+           id="text25">(N+P) × K</text>
+      </g>
+    </g>
+  </g>
+  <!-- Visual indicators for stacking -->
+  <g
+     transform="translate(583,185)"
+     id="g28">
+    <!-- Horizontal stacking arrow -->
+    <line
+       x1="15"
+       y1="40"
+       x2="45"
+       y2="40"
+       stroke="#7b1fa2"
+       stroke-width="2"
+       marker-end="url(#arrowhead)"
+       id="line27" />
+    <text
+       x="30"
+       y="31"
+       text-anchor="middle"
+       font-family="Times, serif"
+       font-size="10px"
+       fill="#7b1fa2"
+       id="text27">horizontal</text>
+    <!-- Vertical stacking arrow -->
+    <line
+       x1="204"
+       y1="-9"
+       x2="204"
+       y2="21"
+       stroke="#7b1fa2"
+       stroke-width="2"
+       marker-end="url(#arrowhead)"
+       id="line28" />
+    <text
+       x="228"
+       y="6"
+       text-anchor="middle"
+       font-family="Times, serif"
+       font-size="10px"
+       fill="#7b1fa2"
+       id="text28">vertical</text>
+  </g>
+  <!-- Arrow marker definition -->
+  <defs
+     id="defs28">
+    <marker
+       id="arrowhead"
+       markerWidth="10"
+       markerHeight="7"
+       refX="9"
+       refY="3.5"
+       orient="auto">
+      <polygon
+         points="10,3.5 0,7 0,0 "
+         fill="#7b1fa2"
+         id="polygon28" />
+    </marker>
+  </defs>
+  <!-- Key/Legend -->
+  <!-- Requirements -->
+  <g
+     transform="translate(551,221)"
+     id="g42" />
+</svg>

--- a/sealir-tutorials/img/matmul_add.svg
+++ b/sealir-tutorials/img/matmul_add.svg
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 538.53845 195.26923"
+   version="1.1"
+   id="svg56"
+   sodipodi:docname="matmul_add.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   width="538.53845"
+   height="195.26923"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs56" />
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.92444444"
+     inkscape:cx="265.02404"
+     inkscape:cy="299.09856"
+     inkscape:window-width="1440"
+     inkscape:window-height="1228"
+     inkscape:window-x="850"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg56" />
+  <!-- Background -->
+  <rect
+     width="537.65857"
+     height="194.38934"
+     fill="#f8f9fa"
+     stroke="#e9ecef"
+     stroke-width="0.879881"
+     id="rect1"
+     style="fill:#ececec"
+     x="0.43994051"
+     y="0.43994051" />
+  <!-- Title -->
+  <text
+     x="264.94229"
+     y="29.000002"
+     text-anchor="middle"
+     font-family="Times, serif"
+     font-size="20px"
+     font-weight="bold"
+     fill="#2c3e50"
+     id="text1">Matrix Multiplication with Addition: A @ (B + C) @ D</text>
+  <!-- Original Expression -->
+  <g
+     transform="translate(70.471156,63.85577)"
+     id="g17">
+    <!-- Expression label -->
+    <text
+       x="0"
+       y="20"
+       font-family="Times, serif"
+       font-size="16px"
+       font-weight="bold"
+       fill="#2c3e50"
+       id="text2">Original Expression:</text>
+    <!-- A @ (B + C) @ D -->
+    <text
+       x="150"
+       y="20"
+       font-family="Times, serif"
+       font-size="18px"
+       fill="#2c3e50"
+       id="text3">A @ (B + C) @ D</text>
+    <!-- Matrix A -->
+    <g
+       transform="translate(0,50)"
+       id="g5">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e3f2fd"
+         stroke="#1976d2"
+         stroke-width="2"
+         id="rect3" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#1976d2"
+         id="text4">A</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text5">M × N</text>
+    </g>
+    <!-- @ symbol -->
+    <text
+       x="75"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text6">@</text>
+    <!-- Opening parenthesis -->
+    <text
+       x="95"
+       y="75"
+       font-family="Times, serif"
+       font-size="20px"
+       fill="#2c3e50"
+       id="text7">(</text>
+    <!-- Matrix B -->
+    <g
+       transform="translate(110,50)"
+       id="g9">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e8f5e8"
+         stroke="#388e3c"
+         stroke-width="2"
+         id="rect7" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#388e3c"
+         id="text8">B</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text9">N × K</text>
+    </g>
+    <!-- + symbol -->
+    <text
+       x="185"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text10">+</text>
+    <!-- Matrix C -->
+    <g
+       transform="translate(200,50)"
+       id="g12">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fce4ec"
+         stroke="#c2185b"
+         stroke-width="2"
+         id="rect10" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#c2185b"
+         id="text11">C</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text12">N × K</text>
+    </g>
+    <!-- Closing parenthesis -->
+    <text
+       x="275"
+       y="75"
+       font-family="Times, serif"
+       font-size="20px"
+       fill="#2c3e50"
+       id="text13">)</text>
+    <!-- @ symbol -->
+    <text
+       x="295"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text14">@</text>
+    <!-- Matrix D -->
+    <g
+       transform="translate(315,50)"
+       id="g16">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fff3e0"
+         stroke="#f57c00"
+         stroke-width="2"
+         id="rect14" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#f57c00"
+         id="text15">D</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text16">K × P</text>
+    </g>
+  </g>
+  <!-- Step 1: Calculate (B + C) -->
+  <!-- Step 2: Calculate A @ (B + C) -->
+  <!-- Step 3: Final multiplication with D -->
+  <!-- Key/Legend -->
+  <g
+     transform="translate(264.94231,179)"
+     id="g53" />
+  <!-- Alternative representation -->
+</svg>

--- a/sealir-tutorials/img/matmul_assoc.svg
+++ b/sealir-tutorials/img/matmul_assoc.svg
@@ -1,0 +1,617 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 800 500"
+   version="1.1"
+   id="svg42"
+   sodipodi:docname="matmul_assoc.svg"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs42" />
+  <sodipodi:namedview
+     id="namedview42"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="2.2515346"
+     inkscape:cx="362.64155"
+     inkscape:cy="280.47537"
+     inkscape:window-width="1728"
+     inkscape:window-height="966"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g18" />
+  <!-- Background -->
+  <rect
+     width="800"
+     height="500"
+     fill="#f8f9fa"
+     stroke="#e9ecef"
+     stroke-width="2"
+     id="rect1"
+     style="fill:#ececec" />
+  <!-- Title -->
+  <text
+     x="400"
+     y="30"
+     text-anchor="middle"
+     font-family="Times, serif"
+     font-size="20"
+     font-weight="bold"
+     fill="#2c3e50"
+     id="text1">
+    Matrix Multiplication Associativity
+  </text>
+  <!-- First Equation: (A × B) × C -->
+  <g
+     transform="translate(50, 80)"
+     id="g18">
+    <!-- Equation label -->
+    <text
+       x="0"
+       y="20"
+       font-family="Times, serif"
+       font-size="16"
+       font-weight="bold"
+       fill="#2c3e50"
+       id="text2">
+      Equation 1:
+    </text>
+    <!-- (A × B) × C -->
+    <text
+       x="100"
+       y="20"
+       font-family="Times, serif"
+       font-size="18"
+       fill="#2c3e50"
+       id="text3">
+      (A × B) × C
+    </text>
+    <!-- Matrix A -->
+    <g
+       transform="translate(0, 50)"
+       id="g5">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e3f2fd"
+         stroke="#1976d2"
+         stroke-width="2"
+         id="rect3" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#1976d2"
+         id="text4">A</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text5">M × N</text>
+    </g>
+    <!-- × symbol -->
+    <text
+       x="76"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text6">×</text>
+    <text
+       x="186.33594"
+       y="75.882812"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text6-4">×</text>
+    <!-- Matrix B -->
+    <g
+       transform="translate(100, 50)"
+       id="g8">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e8f5e8"
+         stroke="#388e3c"
+         stroke-width="2"
+         id="rect6" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#388e3c"
+         id="text7">B</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text8">N × K</text>
+    </g>
+    <!-- = symbol -->
+    <text
+       x="282"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text9">=</text>
+    <!-- Intermediate result (A × B) -->
+    <g
+       transform="translate(302,50)"
+       id="g11">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fff3e0"
+         stroke="#f57c00"
+         stroke-width="2"
+         id="rect9" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#f57c00"
+         id="text10">AB</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text11">M × K</text>
+    </g>
+    <!-- × symbol -->
+    <text
+       x="382"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text12">×</text>
+    <!-- Matrix C -->
+    <g
+       transform="translate(402,50)"
+       id="g14">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fce4ec"
+         stroke="#c2185b"
+         stroke-width="2"
+         id="rect12" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#c2185b"
+         id="text13">C</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text14">K × N</text>
+    </g>
+    <g
+       transform="translate(211,51)"
+       id="g14-9">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fce4ec"
+         stroke="#c2185b"
+         stroke-width="2"
+         id="rect12-8" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#c2185b"
+         id="text13-6">C</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text14-5">K × N</text>
+    </g>
+    <!-- = symbol -->
+    <text
+       x="482"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text15">=</text>
+    <!-- Final result -->
+    <g
+       transform="translate(502,50)"
+       id="g17">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#f3e5f5"
+         stroke="#7b1fa2"
+         stroke-width="2"
+         id="rect15" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14px"
+         font-weight="bold"
+         fill="#7b1fa2"
+         id="text16">ABC</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12px"
+         fill="#666666"
+         id="text17">M × N</text>
+    </g>
+    <!-- Parentheses indication -->
+    <path
+       d="M -5 45 Q -15 45 -15 70 Q -15 95 -5 95"
+       stroke="#666"
+       stroke-width="2"
+       fill="none"
+       id="path17" />
+    <path
+       d="m 165,45 q 10,0 10,25 0,25 -10,25"
+       stroke="#666666"
+       stroke-width="2"
+       fill="none"
+       id="path18" />
+  </g>
+  <!-- Second Equation: A × (B × C) -->
+  <g
+     transform="translate(50, 250)"
+     id="g37">
+    <!-- Equation label -->
+    <text
+       x="0"
+       y="20"
+       font-family="Times, serif"
+       font-size="16"
+       font-weight="bold"
+       fill="#2c3e50"
+       id="text18">
+      Equation 2:
+    </text>
+    <!-- A × (B × C) -->
+    <text
+       x="100"
+       y="20"
+       font-family="Times, serif"
+       font-size="18"
+       fill="#2c3e50"
+       id="text19">
+      A × (B × C)
+    </text>
+    <!-- Matrix A -->
+    <g
+       transform="translate(0, 50)"
+       id="g21">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e3f2fd"
+         stroke="#1976d2"
+         stroke-width="2"
+         id="rect19" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#1976d2"
+         id="text20">A</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text21">M × N</text>
+    </g>
+    <!-- × symbol -->
+    <text
+       x="70"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text22">×</text>
+    <!-- Matrix B -->
+    <g
+       transform="translate(100, 50)"
+       id="g24">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e8f5e8"
+         stroke="#388e3c"
+         stroke-width="2"
+         id="rect22" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#388e3c"
+         id="text23">B</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text24">N × K</text>
+    </g>
+    <!-- × symbol -->
+    <text
+       x="178"
+       y="75"
+       font-family="Times, serif"
+       font-size="16px"
+       fill="#2c3e50"
+       id="text25">×</text>
+    <!-- Matrix C -->
+    <g
+       transform="translate(200, 50)"
+       id="g27">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fce4ec"
+         stroke="#c2185b"
+         stroke-width="2"
+         id="rect25" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#c2185b"
+         id="text26">C</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text27">K × N</text>
+    </g>
+    <!-- = symbol -->
+    <text
+       x="280"
+       y="75"
+       font-family="Times, serif"
+       font-size="16"
+       fill="#2c3e50"
+       id="text28">=</text>
+    <!-- Matrix A (repeated) -->
+    <g
+       transform="translate(300, 50)"
+       id="g30">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#e3f2fd"
+         stroke="#1976d2"
+         stroke-width="2"
+         id="rect28" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#1976d2"
+         id="text29">A</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text30">M × N</text>
+    </g>
+    <!-- × symbol -->
+    <text
+       x="380"
+       y="75"
+       font-family="Times, serif"
+       font-size="16"
+       fill="#2c3e50"
+       id="text31">×</text>
+    <!-- Intermediate result (B × C) -->
+    <g
+       transform="translate(400, 50)"
+       id="g33">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#fff3e0"
+         stroke="#f57c00"
+         stroke-width="2"
+         id="rect31" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#f57c00"
+         id="text32">BC</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text33">N × N</text>
+    </g>
+    <!-- = symbol -->
+    <text
+       x="480"
+       y="75"
+       font-family="Times, serif"
+       font-size="16"
+       fill="#2c3e50"
+       id="text34">=</text>
+    <!-- Final result -->
+    <g
+       transform="translate(500, 50)"
+       id="g36">
+      <rect
+         x="0"
+         y="0"
+         width="60"
+         height="40"
+         fill="#f3e5f5"
+         stroke="#7b1fa2"
+         stroke-width="2"
+         id="rect34" />
+      <text
+         x="30"
+         y="25"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="14"
+         font-weight="bold"
+         fill="#7b1fa2"
+         id="text35">ABC</text>
+      <text
+         x="30"
+         y="55"
+         text-anchor="middle"
+         font-family="Times, serif"
+         font-size="12"
+         fill="#666"
+         id="text36">M × N</text>
+    </g>
+    <!-- Parentheses indication -->
+    <path
+       d="M 95 45 Q 85 45 85 70 Q 85 95 95 95"
+       stroke="#666"
+       stroke-width="2"
+       fill="none"
+       id="path36" />
+    <path
+       d="M 265 45 Q 275 45 275 70 Q 275 95 265 95"
+       stroke="#666"
+       stroke-width="2"
+       fill="none"
+       id="path37" />
+  </g>
+  <!-- Key/Legend -->
+  <!-- Note about associativity -->
+  <g
+     transform="translate(400, 400)"
+     id="g42">
+    <text
+       x="0"
+       y="20"
+       font-family="Times, serif"
+       font-size="16"
+       font-weight="bold"
+       fill="#2c3e50"
+       id="text40">
+      Associativity Property:
+    </text>
+    <text
+       x="0"
+       y="40"
+       font-family="Times, serif"
+       font-size="14"
+       fill="#666"
+       id="text41"
+       style="fill:#333333">
+      (A × B) × C = A × (B × C)
+    </text>
+    <text
+       x="0"
+       y="60"
+       font-family="Times, serif"
+       font-size="14"
+       fill="#666"
+       id="text42"
+       style="fill:#333333">
+      The order of operations doesn't affect the result
+    </text>
+  </g>
+</svg>

--- a/sealir-tutorials/utils/__init__.py
+++ b/sealir-tutorials/utils/__init__.py
@@ -1,17 +1,15 @@
-from .expr_tree_builder import visualize_expr_tree
-from .notebookutils import *
-from .pipeline import Pipeline
-from .report import Report
-from .benchmark import timeit, visualize_benchmark
-
-
 from egglog import EGraph
 from egglog.bindings import RunReport
 from IPython.display import HTML
 
-
+from .benchmark import timeit, visualize_benchmark
+from .expr_tree_builder import visualize_expr_tree
+from .notebookutils import *
+from .pipeline import Pipeline
+from .report import Report
 
 # Report extensions
+
 
 def egraph_to_svg(egraph: EGraph) -> HTML:
     content = egraph._graphviz()
@@ -66,11 +64,12 @@ def egraph_to_svg(egraph: EGraph) -> HTML:
     """
     )
 
+
 def _egraph_renderer(report, content: EGraph):
     return report._render_content(egraph_to_svg(content))
 
-Report.renderer[EGraph] = _egraph_renderer
 
+Report.renderer[EGraph] = _egraph_renderer
 
 
 def _egraph_runreport_renderer(report, content: RunReport):
@@ -113,12 +112,14 @@ def _egraph_runreport_renderer(report, content: RunReport):
         rows = []
         for key, value in sorted(data_dict.items()):
             formatted_value = value_formatter(value)
-            rows.append(f"""
+            rows.append(
+                f"""
                 <tr>
                     <td style="padding: 8px 12px; border-bottom: 1px solid #444; font-family: 'SF Mono', 'Monaco', 'Menlo', 'Consolas', monospace; color: #e1e1e1;">{key}</td>
                     <td style="padding: 8px 12px; border-bottom: 1px solid #444; text-align: right; color: #e1e1e1;">{formatted_value}</td>
                 </tr>
-            """)
+            """
+            )
 
         return f"""
         <div style="margin: 15px 0;">
@@ -138,8 +139,9 @@ def _egraph_runreport_renderer(report, content: RunReport):
         """
 
     # Build HTML content
-    html_parts = []# Add overall status
-    html_parts.append(f"""
+    html_parts = []  # Add overall status
+    html_parts.append(
+        f"""
     <div style="margin: 15px 0; padding: 12px 16px;
                 background-color: {'rgba(40, 167, 69, 0.15)' if content.updated else 'rgba(220, 53, 69, 0.15)'};
                 border: 1px solid {'#28a745' if content.updated else '#dc3545'};
@@ -147,15 +149,50 @@ def _egraph_runreport_renderer(report, content: RunReport):
         <strong style="color: {'#4ade80' if content.updated else '#f87171'};">Run Status:</strong>
         <span style="color: #e1e1e1;">{'Updated' if content.updated else 'No updates'}</span>
     </div>
-    """)
+    """
+    )
 
     # Create tables for each dictionary
-    html_parts.append(create_table("Search Time Per Rule", content.search_time_per_rule, format_timedelta))
-    html_parts.append(create_table("Apply Time Per Rule", content.apply_time_per_rule, format_timedelta))
-    html_parts.append(create_table("Search Time Per Ruleset", content.search_time_per_ruleset, format_timedelta))
-    html_parts.append(create_table("Apply Time Per Ruleset", content.apply_time_per_ruleset, format_timedelta))
-    html_parts.append(create_table("Rebuild Time Per Ruleset", content.rebuild_time_per_ruleset, format_timedelta))
-    html_parts.append(create_table("Number of Matches Per Rule", content.num_matches_per_rule))
+    html_parts.append(
+        create_table(
+            "Search Time Per Rule",
+            content.search_time_per_rule,
+            format_timedelta,
+        )
+    )
+    html_parts.append(
+        create_table(
+            "Apply Time Per Rule",
+            content.apply_time_per_rule,
+            format_timedelta,
+        )
+    )
+    html_parts.append(
+        create_table(
+            "Search Time Per Ruleset",
+            content.search_time_per_ruleset,
+            format_timedelta,
+        )
+    )
+    html_parts.append(
+        create_table(
+            "Apply Time Per Ruleset",
+            content.apply_time_per_ruleset,
+            format_timedelta,
+        )
+    )
+    html_parts.append(
+        create_table(
+            "Rebuild Time Per Ruleset",
+            content.rebuild_time_per_ruleset,
+            format_timedelta,
+        )
+    )
+    html_parts.append(
+        create_table(
+            "Number of Matches Per Rule", content.num_matches_per_rule
+        )
+    )
 
     # Wrap everything in a container
     full_html = f"""
@@ -202,14 +239,18 @@ def _egraph_runreport_renderer_nested(report, content: RunReport):
         else:
             return f"{total_seconds:.3f}s"
 
-    def add_dict_to_report(parent_report, title, data_dict, value_formatter=None):
+    def add_dict_to_report(
+        parent_report, title, data_dict, value_formatter=None
+    ):
         """Add a dictionary as a nested report"""
         if value_formatter is None:
             value_formatter = str
 
         section_report = Report(title, default_expanded=True)
 
-        for key, value in sorted(data_dict.items(), key=lambda x: x[1], reverse=True):
+        for key, value in sorted(
+            data_dict.items(), key=lambda x: x[1], reverse=True
+        ):
             formatted_value = value_formatter(value)
             section_report.append(key, formatted_value)
 
@@ -224,13 +265,41 @@ def _egraph_runreport_renderer_nested(report, content: RunReport):
     main_report.append("Updated", content.updated)
 
     # Add each section as a nested report
-    add_dict_to_report(main_report, "Search Time Per Rule", content.search_time_per_rule, format_timedelta)
-    add_dict_to_report(main_report, "Apply Time Per Rule", content.apply_time_per_rule, format_timedelta)
-    add_dict_to_report(main_report, "Search Time Per Ruleset", content.search_time_per_ruleset, format_timedelta)
-    add_dict_to_report(main_report, "Apply Time Per Ruleset", content.apply_time_per_ruleset, format_timedelta)
-    add_dict_to_report(main_report, "Rebuild Time Per Ruleset", content.rebuild_time_per_ruleset, format_timedelta)
-    add_dict_to_report(main_report, "Number of Matches Per Rule", content.num_matches_per_rule)
+    add_dict_to_report(
+        main_report,
+        "Search Time Per Rule",
+        content.search_time_per_rule,
+        format_timedelta,
+    )
+    add_dict_to_report(
+        main_report,
+        "Apply Time Per Rule",
+        content.apply_time_per_rule,
+        format_timedelta,
+    )
+    add_dict_to_report(
+        main_report,
+        "Search Time Per Ruleset",
+        content.search_time_per_ruleset,
+        format_timedelta,
+    )
+    add_dict_to_report(
+        main_report,
+        "Apply Time Per Ruleset",
+        content.apply_time_per_ruleset,
+        format_timedelta,
+    )
+    add_dict_to_report(
+        main_report,
+        "Rebuild Time Per Ruleset",
+        content.rebuild_time_per_ruleset,
+        format_timedelta,
+    )
+    add_dict_to_report(
+        main_report, "Number of Matches Per Rule", content.num_matches_per_rule
+    )
 
     return report._render_content(main_report)
+
 
 Report.renderer[RunReport] = _egraph_runreport_renderer_nested

--- a/sealir-tutorials/utils/__init__.py
+++ b/sealir-tutorials/utils/__init__.py
@@ -2,3 +2,234 @@ from .expr_tree_builder import visualize_expr_tree
 from .notebookutils import *
 from .pipeline import Pipeline
 from .report import Report
+
+
+from egglog import EGraph
+from egglog.bindings import RunReport
+from IPython.display import HTML
+
+
+
+# Report extensions
+
+def egraph_to_svg(egraph: EGraph) -> HTML:
+    content = egraph._graphviz()
+    svg_raw = content.pipe(format="svg", quiet=True)
+    svg_str = (
+        svg_raw.decode("utf-8") if isinstance(svg_raw, bytes) else svg_str
+    )
+
+    svg_data = svg_str
+
+    # Escape the SVG data properly for JavaScript
+    svg_escaped = (
+        svg_data.replace("\\", "\\\\").replace("`", "\\`").replace("$", "\\$")
+    )
+
+    return HTML(
+        f"""
+    <div style="margin: 10px 0;">
+        <button onclick="openSVGInNewTab()" style="
+            margin-bottom: 10px;
+            padding: 8px 16px;
+            background: #007cba;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        ">Open Full Size in New Tab</button>
+
+        <div style="
+            overflow: auto;
+            border: 1px solid #ccc;
+            resize: both;
+            min-width: 10em;
+            min-height: 3em;
+        ">
+            {svg_data}
+        </div>
+    </div>
+
+    <script>
+    function openSVGInNewTab() {{
+        const svgData = `{svg_escaped}`;
+        const blob = new Blob([svgData], {{type: 'image/svg+xml;charset=utf-8'}});
+        const url = URL.createObjectURL(blob);
+        const newWindow = window.open();
+        newWindow.location.href = url;
+
+        // Clean up after a delay
+        setTimeout(() => URL.revokeObjectURL(url), 2000);
+    }}
+    </script>
+    """
+    )
+
+def _egraph_renderer(report, content: EGraph):
+    return report._render_content(egraph_to_svg(content))
+
+Report.renderer[EGraph] = _egraph_renderer
+
+
+
+def _egraph_runreport_renderer(report, content: RunReport):
+    """
+    class RunReport:
+        updated: bool
+        search_time_per_rule: dict[str, timedelta]
+        apply_time_per_rule: dict[str, timedelta]
+        search_time_per_ruleset: dict[str, timedelta]
+        apply_time_per_ruleset: dict[str, timedelta]
+        rebuild_time_per_ruleset: dict[str, timedelta]
+        num_matches_per_rule: dict[str, int]
+    """
+
+    def format_timedelta(td):
+        """Format timedelta to a readable string"""
+        if td is None:
+            return "N/A"
+        total_seconds = td.total_seconds()
+        if total_seconds < 0.001:
+            return f"{total_seconds * 1000000:.1f}μs"
+        elif total_seconds < 1:
+            return f"{total_seconds * 1000:.1f}ms"
+        else:
+            return f"{total_seconds:.3f}s"
+
+    def create_table(title, data_dict, value_formatter=None):
+        """Create an HTML table for a dictionary"""
+        if not data_dict:
+            return f"""
+            <div style="margin: 15px 0;">
+                <h3 style="color: #e1e1e1; margin-bottom: 10px;">{title}</h3>
+                <p style="color: #999; font-style: italic;">No data available</p>
+            </div>
+            """
+
+        if value_formatter is None:
+            value_formatter = str
+
+        rows = []
+        for key, value in sorted(data_dict.items()):
+            formatted_value = value_formatter(value)
+            rows.append(f"""
+                <tr>
+                    <td style="padding: 8px 12px; border-bottom: 1px solid #444; font-family: 'SF Mono', 'Monaco', 'Menlo', 'Consolas', monospace; color: #e1e1e1;">{key}</td>
+                    <td style="padding: 8px 12px; border-bottom: 1px solid #444; text-align: right; color: #e1e1e1;">{formatted_value}</td>
+                </tr>
+            """)
+
+        return f"""
+        <div style="margin: 15px 0;">
+            <h3 style="color: #e1e1e1; margin-bottom: 10px; font-weight: 600;">{title}</h3>
+            <table style="border-collapse: collapse; width: 100%; max-width: 600px; border: 1px solid #555; background-color: #1e1e1e;">
+                <thead>
+                    <tr style="background-color: #2a2a2a;">
+                        <th style="padding: 10px 12px; text-align: left; border-bottom: 2px solid #555; color: #e1e1e1; font-weight: 600;">Item</th>
+                        <th style="padding: 10px 12px; text-align: right; border-bottom: 2px solid #555; color: #e1e1e1; font-weight: 600;">Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {''.join(rows)}
+                </tbody>
+            </table>
+        </div>
+        """
+
+    # Build HTML content
+    html_parts = []# Add overall status
+    html_parts.append(f"""
+    <div style="margin: 15px 0; padding: 12px 16px;
+                background-color: {'rgba(40, 167, 69, 0.15)' if content.updated else 'rgba(220, 53, 69, 0.15)'};
+                border: 1px solid {'#28a745' if content.updated else '#dc3545'};
+                border-radius: 6px; color: #e1e1e1;">
+        <strong style="color: {'#4ade80' if content.updated else '#f87171'};">Run Status:</strong>
+        <span style="color: #e1e1e1;">{'Updated' if content.updated else 'No updates'}</span>
+    </div>
+    """)
+
+    # Create tables for each dictionary
+    html_parts.append(create_table("Search Time Per Rule", content.search_time_per_rule, format_timedelta))
+    html_parts.append(create_table("Apply Time Per Rule", content.apply_time_per_rule, format_timedelta))
+    html_parts.append(create_table("Search Time Per Ruleset", content.search_time_per_ruleset, format_timedelta))
+    html_parts.append(create_table("Apply Time Per Ruleset", content.apply_time_per_ruleset, format_timedelta))
+    html_parts.append(create_table("Rebuild Time Per Ruleset", content.rebuild_time_per_ruleset, format_timedelta))
+    html_parts.append(create_table("Number of Matches Per Rule", content.num_matches_per_rule))
+
+    # Wrap everything in a container
+    full_html = f"""
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                line-height: 1.4; background-color: #0d1117; padding: 20px; border-radius: 8px;
+                border: 1px solid #30363d; color: #e1e1e1;">
+        <h2 style="color: #f0f6fc; margin-bottom: 20px; border-bottom: 2px solid #30363d;
+                   padding-bottom: 10px; font-weight: 600;">
+            EGraph Run Report
+        </h2>
+        {''.join(html_parts)}
+    </div>
+    """
+
+    return report._render_content(HTML(full_html))
+
+
+def _egraph_runreport_renderer_nested(report, content: RunReport):
+    """
+    Alternative implementation using nested Report objects instead of HTML tables.
+
+    class RunReport:
+        updated: bool
+        search_time_per_rule: dict[str, timedelta]
+        apply_time_per_rule: dict[str, timedelta]
+        search_time_per_ruleset: dict[str, timedelta]
+        apply_time_per_ruleset: dict[str, timedelta]
+        rebuild_time_per_ruleset: dict[str, timedelta]
+        num_matches_per_rule: dict[str, int]
+    """
+
+    def format_timedelta(td):
+        """Format timedelta to a readable string"""
+        if td is None:
+            return "N/A"
+        total_seconds = td.total_seconds()
+
+        if total_seconds < 0.000001:
+            return f"{total_seconds * 1000000000:.1f}ns"
+        elif total_seconds < 0.001:
+            return f"{total_seconds * 1000000:.1f}μs"
+        elif total_seconds < 1:
+            return f"{total_seconds * 1000:.1f}ms"
+        else:
+            return f"{total_seconds:.3f}s"
+
+    def add_dict_to_report(parent_report, title, data_dict, value_formatter=None):
+        """Add a dictionary as a nested report"""
+        if value_formatter is None:
+            value_formatter = str
+
+        section_report = Report(title, default_expanded=True)
+
+        for key, value in sorted(data_dict.items(), key=lambda x: x[1], reverse=True):
+            formatted_value = value_formatter(value)
+            section_report.append(key, formatted_value)
+
+        parent_report.append(title, section_report)
+
+    # Import Report class
+
+    # Create main report
+    main_report = Report("EGraph Run Report")
+
+    # Add overall status
+    main_report.append("Updated", content.updated)
+
+    # Add each section as a nested report
+    add_dict_to_report(main_report, "Search Time Per Rule", content.search_time_per_rule, format_timedelta)
+    add_dict_to_report(main_report, "Apply Time Per Rule", content.apply_time_per_rule, format_timedelta)
+    add_dict_to_report(main_report, "Search Time Per Ruleset", content.search_time_per_ruleset, format_timedelta)
+    add_dict_to_report(main_report, "Apply Time Per Ruleset", content.apply_time_per_ruleset, format_timedelta)
+    add_dict_to_report(main_report, "Rebuild Time Per Ruleset", content.rebuild_time_per_ruleset, format_timedelta)
+    add_dict_to_report(main_report, "Number of Matches Per Rule", content.num_matches_per_rule)
+
+    return report._render_content(main_report)
+
+Report.renderer[RunReport] = _egraph_runreport_renderer_nested

--- a/sealir-tutorials/utils/__init__.py
+++ b/sealir-tutorials/utils/__init__.py
@@ -2,6 +2,7 @@ from .expr_tree_builder import visualize_expr_tree
 from .notebookutils import *
 from .pipeline import Pipeline
 from .report import Report
+from .benchmark import timeit, visualize_benchmark
 
 
 from egglog import EGraph

--- a/sealir-tutorials/utils/benchmark.py
+++ b/sealir-tutorials/utils/benchmark.py
@@ -7,8 +7,6 @@ import statistics
 import timeit as _timeit
 from typing import Callable, Optional
 
-from . import IN_NOTEBOOK
-
 
 class TimeitResult:
     """Container for timing results with IPython-like formatting."""
@@ -78,6 +76,8 @@ def visualize_benchmark(
         >>> result2 = timeit(func2)
         >>> visualize_benchmark(result1, result2, labels=["Unoptimized", "Optimized"])
     """
+    from . import IN_NOTEBOOK
+
     try:
         import matplotlib.pyplot as plt
         import numpy as np

--- a/sealir-tutorials/utils/benchmark.py
+++ b/sealir-tutorials/utils/benchmark.py
@@ -1,0 +1,191 @@
+"""
+A timeit module that provides IPython-like %timeit functionality without IPython.
+Built on top of Python's standard timeit module.
+"""
+
+import statistics
+import timeit as _timeit
+from typing import Callable, Optional
+
+from . import IN_NOTEBOOK
+
+
+class TimeitResult:
+    """Container for timing results with IPython-like formatting."""
+
+    def __init__(self, times: list, loops: int, repeat: int):
+        self.times = times
+        self.loops = loops
+        self.repeat = repeat
+        self.best = min(times) / self.loops
+        self.worst = max(times) / self.loops
+        self.mean = statistics.mean(times) / self.loops
+        self.stdev = (
+            statistics.stdev(times) / self.loops if len(times) > 1 else 0
+        )
+
+    def __str__(self):
+        # Format time with appropriate units
+        def format_time(seconds):
+            if seconds >= 1:
+                return f"{seconds:.3f} s"
+            elif seconds >= 1e-3:
+                return f"{seconds*1e3:.3f} ms"
+            elif seconds >= 1e-6:
+                return f"{seconds*1e6:.3f} µs"
+            else:
+                return f"{seconds*1e9:.3f} ns"
+
+        per_loop = self.best
+        if self.repeat == 1:
+            return f"{format_time(per_loop)} per loop (mean ± std. dev. of 1 run, {self.loops} loop{'s' if self.loops != 1 else ''} each)"
+        else:
+            return f"{format_time(per_loop)} per loop (mean ± std. dev. of {self.repeat} runs, {self.loops} loop{'s' if self.loops != 1 else ''} each)"
+
+    def __repr__(self):
+        return f"TimeitResult(best={self.best:.6f}s, mean={self.mean:.6f}s, loops={self.loops}, repeat={self.repeat})"
+
+
+def timeit(
+    func: Callable,
+    repeat: int = 5,
+    number: Optional[int] = None,
+):
+    # Create Timer object
+    timer = _timeit.Timer(stmt=func)
+    # Auto-determine number of loops if not specified
+    if number is None:
+        number = timer.autorange()[0]
+    # Run repeat times and collect results
+    times = timer.repeat(repeat=repeat, number=number)
+    return TimeitResult(times, number, repeat)
+
+
+def visualize_benchmark(
+    *results, labels=None, title="Benchmark Comparison", figsize=(10, 6)
+):
+    """
+    Visualize benchmark results using matplotlib.
+
+    Args:
+        *results: TimeitResult objects to compare
+        labels: List of labels for each result (optional, will use default names)
+        title: Title for the plot
+        figsize: Figure size tuple
+
+    Example:
+        >>> result1 = timeit(func1)
+        >>> result2 = timeit(func2)
+        >>> visualize_benchmark(result1, result2, labels=["Unoptimized", "Optimized"])
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        print(
+            "matplotlib is required for visualization. Install with: pip install matplotlib"
+        )
+        return
+
+    if not results:
+        print("No results provided for visualization")
+        return
+
+    # Generate default labels if not provided
+    if labels is None:
+        labels = [f"Method {i+1}" for i in range(len(results))]
+    elif len(labels) != len(results):
+        print(
+            f"Warning: {len(labels)} labels provided for {len(results)} results"
+        )
+        labels = labels[: len(results)] + [
+            f"Method {i+1}" for i in range(len(labels), len(results))
+        ]
+
+    # Create figure with subplots (now only 1 row, 2 columns)
+    fig, (ax2, ax3) = plt.subplots(1, 2, figsize=figsize)
+    fig.suptitle(title, fontsize=16, fontweight="bold")
+
+    # Extract data
+    names = labels
+    bests = [r.best for r in results]
+
+    # 1. Box plot of all timing runs (ax2)
+    cmap = plt.get_cmap("Set3")
+    colors = cmap(np.linspace(0, 1, len(results)))
+    all_times = []
+    for result in results:
+        per_loop_times = [t / result.loops for t in result.times]
+        all_times.append(per_loop_times)
+
+    bp = ax2.boxplot(all_times, labels=names, patch_artist=True)
+    for patch, color in zip(bp["boxes"], colors):
+        patch.set_facecolor(color)
+        patch.set_alpha(0.7)
+    ax2.set_ylabel("Time per loop (seconds)")
+    ax2.set_title("Distribution of Times")
+    ax2.tick_params(axis="x", rotation=45)
+
+    # 2. Speedup comparison (relative to first result) (ax3)
+    if len(results) > 1:
+        baseline = bests[0]
+        speedups = [baseline / best for best in bests]
+        bars = ax3.bar(
+            names, speedups, color=colors, alpha=0.7, edgecolor="black"
+        )
+        ax3.set_ylabel("Speedup Factor")
+        ax3.set_title("Relative Speedup")
+        ax3.axhline(y=1.0, color="red", linestyle="--", alpha=0.5)
+        ax3.tick_params(axis="x", rotation=45)
+
+        # Add value labels
+        for bar, speedup in zip(bars, speedups):
+            height = bar.get_height()
+            ax3.text(
+                bar.get_x() + bar.get_width() / 2.0,
+                height,
+                f"{speedup:.2f}x",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+            )
+    else:
+        ax3.text(
+            0.5,
+            0.5,
+            "Need at least 2 results\nfor speedup comparison",
+            ha="center",
+            va="center",
+            transform=ax3.transAxes,
+            fontsize=12,
+        )
+        ax3.set_title("Relative Speedup")
+
+    plt.tight_layout()
+    if IN_NOTEBOOK:
+        plt.show()
+
+    # Print summary
+    print("\n" + "=" * 50)
+    print("BENCHMARK SUMMARY")
+    print("=" * 50)
+
+    if len(results) > 1:
+        best_idx = np.argmin(bests)
+        print(f"Fastest: {names[best_idx]}")
+        print(f"   Time: {bests[best_idx]:.2e} seconds per loop")
+
+        print(f"\nSpeedup factors (vs {names[0]}):")
+        baseline = bests[0]
+        for i, (name, best) in enumerate(zip(names, bests)):
+            speedup = baseline / best
+            if speedup > 1:
+                print(f"   {name}: {speedup:.2f}x faster")
+            elif speedup < 1:
+                print(f"   {name}: {1/speedup:.2f}x slower")
+            else:
+                print(f"   {name}: baseline")
+
+    print(f"\nAll results:")
+    for name, result in zip(names, results):
+        print(f"   {name}: {result}")

--- a/sealir-tutorials/utils/benchmark.py
+++ b/sealir-tutorials/utils/benchmark.py
@@ -59,48 +59,10 @@ def timeit(
     return TimeitResult(times, number, repeat)
 
 
-def visualize_benchmark(
-    *results, labels=None, title="Benchmark Comparison", figsize=(10, 6)
-):
-    """
-    Visualize benchmark results using matplotlib.
-
-    Args:
-        *results: TimeitResult objects to compare
-        labels: List of labels for each result (optional, will use default names)
-        title: Title for the plot
-        figsize: Figure size tuple
-
-    Example:
-        >>> result1 = timeit(func1)
-        >>> result2 = timeit(func2)
-        >>> visualize_benchmark(result1, result2, labels=["Unoptimized", "Optimized"])
-    """
-    from . import IN_NOTEBOOK
-
-    try:
-        import matplotlib.pyplot as plt
-        import numpy as np
-    except ImportError:
-        print(
-            "matplotlib is required for visualization. Install with: pip install matplotlib"
-        )
-        return
-
-    if not results:
-        print("No results provided for visualization")
-        return
-
-    # Generate default labels if not provided
-    if labels is None:
-        labels = [f"Method {i+1}" for i in range(len(results))]
-    elif len(labels) != len(results):
-        print(
-            f"Warning: {len(labels)} labels provided for {len(results)} results"
-        )
-        labels = labels[: len(results)] + [
-            f"Method {i+1}" for i in range(len(labels), len(results))
-        ]
+def _create_matplotlib_plots(results, labels, title, figsize):
+    """Create matplotlib plots for benchmark visualization."""
+    import matplotlib.pyplot as plt
+    import numpy as np
 
     # Create figure with subplots (now only 1 row, 2 columns)
     fig, (ax2, ax3) = plt.subplots(1, 2, figsize=figsize)
@@ -162,8 +124,14 @@ def visualize_benchmark(
         ax3.set_title("Relative Speedup")
 
     plt.tight_layout()
-    if IN_NOTEBOOK:
-        plt.show()
+    plt.show()
+
+
+def _print_benchmark_summary(results, labels):
+    """Print benchmark summary without using matplotlib/numpy."""
+    # Extract data
+    names = labels
+    bests = [r.best for r in results]
 
     # Print summary
     print("\n" + "=" * 50)
@@ -171,7 +139,7 @@ def visualize_benchmark(
     print("=" * 50)
 
     if len(results) > 1:
-        best_idx = np.argmin(bests)
+        best_idx = min(range(len(bests)), key=lambda i: bests[i])
         print(f"Fastest: {names[best_idx]}")
         print(f"   Time: {bests[best_idx]:.2e} seconds per loop")
 
@@ -189,3 +157,50 @@ def visualize_benchmark(
     print(f"\nAll results:")
     for name, result in zip(names, results):
         print(f"   {name}: {result}")
+
+
+def visualize_benchmark(
+    *results, labels=None, title="Benchmark Comparison", figsize=(10, 6),
+    show_plots=None,
+):
+    """
+    Visualize benchmark results using matplotlib.
+
+    Args:
+        *results: TimeitResult objects to compare
+        labels: List of labels for
+        each result (optional, will use default names)
+        title: Title for the plot
+        figsize: Figure size tuple
+        show_plots: Whether to display matplotlib plots.
+                    If None, plots are shown only in notebook environments.
+
+    Example:
+        >>> result1 = timeit(func1)
+        >>> result2 = timeit(func2)
+        >>> visualize_benchmark(result1, result2,
+                                labels=["Unoptimized", "Optimized"])
+    """
+    from . import IN_NOTEBOOK
+
+    if not results:
+        print("No results provided for visualization")
+        return
+
+    # Generate default labels if not provided
+    if labels is None:
+        labels = [f"Method {i+1}" for i in range(len(results))]
+    elif len(labels) != len(results):
+        print(
+            f"Warning: {len(labels)} labels provided for {len(results)} results"
+        )
+        labels = labels[: len(results)] + [
+            f"Method {i+1}" for i in range(len(labels), len(results))
+        ]
+
+    # Create plots only if in notebook environment
+    if show_plots or (show_plots is None and IN_NOTEBOOK):
+        _create_matplotlib_plots(results, labels, title, figsize)
+
+    # Always print the summary (non-matplotlib functionality)
+    _print_benchmark_summary(results, labels)

--- a/sealir-tutorials/utils/report.py
+++ b/sealir-tutorials/utils/report.py
@@ -7,11 +7,9 @@ import uuid
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from pprint import pformat
 from timeit import default_timer as timer
 
-from egglog import EGraph
-from IPython.display import HTML, SVG, display
+from IPython.display import HTML, display
 
 from .notebookutils import IN_NOTEBOOK
 
@@ -31,58 +29,6 @@ def remove_svg_constraints_xml(svg_str):
     return ET.tostring(root, encoding="unicode")
 
 
-def egraph_to_svg(egraph: EGraph) -> HTML:
-    content = egraph._graphviz()
-    svg_raw = content.pipe(format="svg", quiet=True)
-    svg_str = (
-        svg_raw.decode("utf-8") if isinstance(svg_raw, bytes) else svg_str
-    )
-
-    svg_data = svg_str
-
-    # Escape the SVG data properly for JavaScript
-    svg_escaped = (
-        svg_data.replace("\\", "\\\\").replace("`", "\\`").replace("$", "\\$")
-    )
-
-    return HTML(
-        f"""
-    <div style="margin: 10px 0;">
-        <button onclick="openSVGInNewTab()" style="
-            margin-bottom: 10px;
-            padding: 8px 16px;
-            background: #007cba;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-        ">Open Full Size in New Tab</button>
-
-        <div style="
-            overflow: auto;
-            border: 1px solid #ccc;
-            resize: both;
-            min-width: 10em;
-            min-height: 3em;
-        ">
-            {svg_data}
-        </div>
-    </div>
-
-    <script>
-    function openSVGInNewTab() {{
-        const svgData = `{svg_escaped}`;
-        const blob = new Blob([svgData], {{type: 'image/svg+xml;charset=utf-8'}});
-        const url = URL.createObjectURL(blob);
-        const newWindow = window.open();
-        newWindow.location.href = url;
-
-        // Clean up after a delay
-        setTimeout(() => URL.revokeObjectURL(url), 2000);
-    }}
-    </script>
-    """
-    )
 
 
 class ReportInterface(ABC):
@@ -151,14 +97,40 @@ class DummyReport(ReportInterface):
         return f"DummyReport()"
 
 
+
+def format_time(time_seconds: float, decimal_places: int = 1) -> str:
+    """
+    Format time with automatically selected unit (s, ms, μs, ns).
+
+    Args:
+        time_seconds: Time value in seconds
+        decimal_places: Number of decimal places to display
+    """
+    if time_seconds >= 1:
+        return f"{time_seconds:.{decimal_places}f}s"
+    elif time_seconds >= 1e-3:
+        return f"{time_seconds * 1e3:.{decimal_places}f}ms"
+    elif time_seconds >= 1e-6:
+        return f"{time_seconds * 1e6:.{decimal_places}f}μs"
+    else:
+        return f"{time_seconds * 1e9:.{decimal_places}f}ns"
+
+
 class Report(ReportInterface):
     """
     A utility class for creating collapsible panes in Jupyter notebooks.
 
-    Supports both text content and IPython display-able objects (images, plots, etc.).
+    Supports both text content and IPython display-able objects (images, plots,
+    etc.).
+
+    Notes:
+
+    - Timing overhead represents milliseconds consumed by `.append()` rendering
+      operations.
     """
 
     Sink = DummyReport
+    renderer = {}  # Registry for type-specific renderers
 
     def __init__(
         self,
@@ -184,7 +156,8 @@ class Report(ReportInterface):
         """Compute metadata as a dict for timing breakdown."""
         last_time = self._start_time
         timing = []
-        total_overhead_ms = 0
+        total_overhead = 0
+        complete_end_time = timer()
         for pane_info in self.panes:
             title = pane_info["title"]
             end_time = pane_info["end_time"]
@@ -192,35 +165,35 @@ class Report(ReportInterface):
             timing.append(
                 {
                     "title": title,
-                    "elapsed_ms": (end_time - last_time) * 1000,
-                    "overhead_ms": overhead_time * 1000,
+                    "elapsed": (end_time - last_time),
+                    "overhead": overhead_time,
                 }
             )
             last_time = end_time
-            total_overhead_ms += overhead_time
-        total_elapsed = (last_time - self._start_time) * 1000
+            total_overhead += overhead_time
+        total_elapsed = (complete_end_time - self._start_time)
         return {
-            "total_elapsed_ms": total_elapsed,
-            "total_overhead_ms": total_overhead_ms * 1000,
+            "total_elapsed": total_elapsed,
+            "total_overhead": total_overhead,
             "timing": timing,
         }
 
     def _format_metadata(self, metadata_dict):
         """Format the metadata dict as a string."""
-        elapsed = metadata_dict["total_elapsed_ms"]
-        overhead = metadata_dict["total_overhead_ms"]
+        elapsed = metadata_dict["total_elapsed"]
+        overhead = metadata_dict["total_overhead"]
         buf = [
-            f"time elapsed {elapsed:.2f}ms",
-            f"overhead {overhead:.2f}ms",
-            f"elapsed - overhead {elapsed - overhead:.2f}ms",
+            f"time elapsed {format_time(elapsed)}",
+            f"overhead {format_time(overhead)}",
+            f"elapsed - overhead {format_time(elapsed - overhead)}",
             "timing breakdown (+ overhead):",
         ]
         for entry in metadata_dict["timing"]:
-            elapsed = entry["elapsed_ms"]
-            overhead = entry["overhead_ms"]
+            elapsed = entry["elapsed"]
+            overhead = entry["overhead"]
             diff = elapsed - overhead
             buf.append(
-                f"  {diff:.2f}ms (+ {overhead:.2f}ms): {entry['title']:20}"
+                f"  {format_time(diff)} (+ {format_time(overhead)}: {entry['title']:20}"
             )
         return "\n".join(buf)
 
@@ -230,15 +203,13 @@ class Report(ReportInterface):
         try:
             yield report
         finally:
+            meta = report._compute_metadata()
+            elapsed = meta["total_elapsed"]
+            overhead = meta["total_overhead"]
+            elapsed_discounted = elapsed - overhead
             if self.enable_nested_metadata or metadata:
-                meta = report._compute_metadata()
-                elapsed = meta["total_elapsed_ms"]
-                overhead_ms = meta["total_overhead_ms"]
                 report.append("[metadata]", report._format_metadata(meta))
-                elapsed_discounted = elapsed - overhead_ms
-                title = f"{report.title} ({elapsed_discounted:.2f}ms)"
-            else:
-                title = report.title
+            title = f"{report.title}: {format_time(elapsed_discounted)} (+{format_time(overhead)} overhead)"
             self.append(title, report)
 
     def append(self, title, content):
@@ -250,10 +221,54 @@ class Report(ReportInterface):
             self._original_contents = {}
         self._original_contents[pane_id] = content
 
-        if isinstance(content, EGraph):
-            content = egraph_to_svg(content)
+        html_content, is_nested_report = self._render_content(content)
 
-        # Process different content types (same as original)
+        ts_current = timer()
+        self.panes.append(
+            {
+                "id": pane_id,
+                "title": title,
+                "content": html_content,
+                "is_nested_report": is_nested_report,
+                "fallback_content": str(content),
+                "end_time": ts_current,
+                "overhead_time": ts_current - ts_overhead,
+            }
+        )
+
+    def _render_content(self, content):
+        """
+        Render content into HTML format and determine if it's a nested report.
+
+        Args:
+            content: The content to render (can be EGraph, Report, or various display objects)
+
+        Returns:
+            tuple: (html_content, is_nested_report)
+        """
+        # Check for registered custom renderers first
+        content_type = type(content)
+        if content_type in self.renderer:
+            return self.renderer[content_type](self, content)
+
+        # Check for registered renderers by base classes (MRO order)
+        for cls in content_type.__mro__:
+            if cls in self.renderer:
+                return self.renderer[cls](self, content)
+
+        # Fall back to built-in renderers
+        return self._render_builtin_content(content)
+
+    def _render_builtin_content(self, content):
+        """
+        Built-in content rendering logic.
+
+        Args:
+            content: The content to render
+
+        Returns:
+            tuple: (html_content, is_nested_report)
+        """
         if isinstance(content, Report):
             # Nested Report support
             html_content = self._render_nested_report(content)
@@ -289,7 +304,6 @@ class Report(ReportInterface):
                 html_content = content
             else:
                 # Escape HTML and preserve whitespace
-
                 escaped_content = html.escape(content)
                 html_content = f'<pre style="white-space: pre-wrap; font-family: monospace; background-color: #2a2a2a; color: #e0e0e0; padding: 10px; border-radius: 4px; overflow-x: auto; border: 1px solid #404040;">{escaped_content}</pre>'
             is_nested_report = False
@@ -299,18 +313,7 @@ class Report(ReportInterface):
             html_content = f'<pre style="white-space: pre-wrap; font-family: monospace; background-color: #2a2a2a; color: #e0e0e0; padding: 10px; border-radius: 4px; overflow-x: auto; border: 1px solid #404040;">{escaped_content}</pre>'
             is_nested_report = False
 
-        ts_current = timer()
-        self.panes.append(
-            {
-                "id": pane_id,
-                "title": title,
-                "content": html_content,
-                "is_nested_report": is_nested_report,
-                "fallback_content": str(content),
-                "end_time": ts_current,
-                "overhead_time": ts_current - ts_overhead,
-            }
-        )
+        return html_content, is_nested_report
 
     def _render_nested_report(self, nested_report):
         """Render a nested Report as HTML content."""

--- a/sealir-tutorials/utils/report.py
+++ b/sealir-tutorials/utils/report.py
@@ -184,30 +184,44 @@ class Report(ReportInterface):
         """Compute metadata as a dict for timing breakdown."""
         last_time = self._start_time
         timing = []
+        total_overhead_ms = 0
         for pane_info in self.panes:
             title = pane_info["title"]
             end_time = pane_info["end_time"]
+            overhead_time = pane_info["overhead_time"]
             timing.append(
                 {
                     "title": title,
                     "elapsed_ms": (end_time - last_time) * 1000,
+                    "overhead_ms": overhead_time * 1000,
                 }
             )
             last_time = end_time
+            total_overhead_ms += overhead_time
         total_elapsed = (last_time - self._start_time) * 1000
         return {
             "total_elapsed_ms": total_elapsed,
+            "total_overhead_ms": total_overhead_ms * 1000,
             "timing": timing,
         }
 
     def _format_metadata(self, metadata_dict):
         """Format the metadata dict as a string."""
+        elapsed = metadata_dict["total_elapsed_ms"]
+        overhead = metadata_dict["total_overhead_ms"]
         buf = [
-            f"time elapsed {metadata_dict['total_elapsed_ms']:.2f}ms",
-            "timing breakdown:",
+            f"time elapsed {elapsed:.2f}ms",
+            f"overhead {overhead:.2f}ms",
+            f"elapsed - overhead {elapsed - overhead:.2f}ms",
+            "timing breakdown (+ overhead):",
         ]
         for entry in metadata_dict["timing"]:
-            buf.append(f"  {entry['elapsed_ms']:.2f}ms: {entry['title']:20}")
+            elapsed = entry["elapsed_ms"]
+            overhead = entry["overhead_ms"]
+            diff = elapsed - overhead
+            buf.append(
+                f"  {diff:.2f}ms (+ {overhead:.2f}ms): {entry['title']:20}"
+            )
         return "\n".join(buf)
 
     @contextmanager
@@ -219,13 +233,16 @@ class Report(ReportInterface):
             if self.enable_nested_metadata or metadata:
                 meta = report._compute_metadata()
                 elapsed = meta["total_elapsed_ms"]
+                overhead_ms = meta["total_overhead_ms"]
                 report.append("[metadata]", report._format_metadata(meta))
-                title = f"{report.title} ({elapsed:.2f}ms)"
+                elapsed_discounted = elapsed - overhead_ms
+                title = f"{report.title} ({elapsed_discounted:.2f}ms)"
             else:
                 title = report.title
             self.append(title, report)
 
     def append(self, title, content):
+        ts_overhead = timer()
         pane_id = f"pane_{uuid.uuid4().hex[:8]}"
 
         # Store original content for terminal display
@@ -282,6 +299,7 @@ class Report(ReportInterface):
             html_content = f'<pre style="white-space: pre-wrap; font-family: monospace; background-color: #2a2a2a; color: #e0e0e0; padding: 10px; border-radius: 4px; overflow-x: auto; border: 1px solid #404040;">{escaped_content}</pre>'
             is_nested_report = False
 
+        ts_current = timer()
         self.panes.append(
             {
                 "id": pane_id,
@@ -289,7 +307,8 @@ class Report(ReportInterface):
                 "content": html_content,
                 "is_nested_report": is_nested_report,
                 "fallback_content": str(content),
-                "end_time": timer(),
+                "end_time": ts_current,
+                "overhead_time": ts_current - ts_overhead,
             }
         )
 

--- a/sealir-tutorials/utils/report.py
+++ b/sealir-tutorials/utils/report.py
@@ -29,8 +29,6 @@ def remove_svg_constraints_xml(svg_str):
     return ET.tostring(root, encoding="unicode")
 
 
-
-
 class ReportInterface(ABC):
     """
     Abstract interface for report classes.
@@ -95,7 +93,6 @@ class DummyReport(ReportInterface):
 
     def __repr__(self):
         return f"DummyReport()"
-
 
 
 def format_time(time_seconds: float, decimal_places: int = 1) -> str:
@@ -171,7 +168,7 @@ class Report(ReportInterface):
             )
             last_time = end_time
             total_overhead += overhead_time
-        total_elapsed = (complete_end_time - self._start_time)
+        total_elapsed = complete_end_time - self._start_time
         return {
             "total_elapsed": total_elapsed,
             "total_overhead": total_overhead,

--- a/sealir-tutorials/utils/report.py
+++ b/sealir-tutorials/utils/report.py
@@ -365,20 +365,36 @@ class Report(ReportInterface):
             display: flex;
             align-items: center;
             justify-content: space-between;
-            transition: background-color 0.2s ease;
+            transition: background-color 0.2s ease, border-left 0.2s ease;
             font-weight: 400;
             color: #c0c0c0;
             font-size: 1em;
+            border-left: 3px solid #404040;
         }}
 
         .nested-pane-header-{nested_id}:hover {{
             background-color: #333;
         }}
 
+        .nested-pane-header-{nested_id}.expanded {{
+            background-color: #2d2d2d;
+            color: #e0e0e0;
+            font-weight: 500;
+            border-left: 3px solid #007cba;
+        }}
+
+        .nested-pane-header-{nested_id}.expanded:hover {{
+            background-color: #353535;
+        }}
+
         .nested-pane-toggle-{nested_id} {{
             font-size: 1.2em;
             color: #888;
-            transition: transform 0.2s ease;
+            transition: transform 0.2s ease, color 0.2s ease;
+        }}
+
+        .nested-pane-toggle-{nested_id}.expanded {{
+            color: #007cba;
         }}
 
         .nested-pane-content-{nested_id} {{
@@ -397,6 +413,18 @@ class Report(ReportInterface):
         .nested-pane-toggle-{nested_id}.expanded {{
             transform: rotate(90deg);
         }}
+
+        .nested-pane-status-{nested_id} {{
+            font-size: 0.85em;
+            color: #777;
+            font-style: italic;
+            margin-left: 8px;
+            transition: opacity 0.2s ease;
+        }}
+
+        .nested-pane-status-{nested_id}.expanded {{
+            opacity: 0;
+        }}
         </style>
         """
 
@@ -406,13 +434,19 @@ class Report(ReportInterface):
         function toggleNestedPane_{nested_id}(paneId) {{
             const content = document.getElementById(paneId + '_content');
             const toggle = document.getElementById(paneId + '_toggle');
+            const header = document.getElementById(paneId + '_header');
+            const status = document.getElementById(paneId + '_status');
 
             if (content.classList.contains('expanded')) {{
                 content.classList.remove('expanded');
                 toggle.classList.remove('expanded');
+                header.classList.remove('expanded');
+                status.classList.remove('expanded');
             }} else {{
                 content.classList.add('expanded');
                 toggle.classList.add('expanded');
+                header.classList.add('expanded');
+                status.classList.add('expanded');
             }}
         }}
         </script>
@@ -424,8 +458,8 @@ class Report(ReportInterface):
             expanded_class = "expanded" if self.default_expanded else ""
             panes_html += f"""
             <div class="nested-pane-{nested_id}">
-                <div class="nested-pane-header-{nested_id}" onclick="toggleNestedPane_{nested_id}('{pane['id']}')">
-                    <span>{pane['title']}</span>
+                <div id="{pane['id']}_header" class="nested-pane-header-{nested_id} {expanded_class}" onclick="toggleNestedPane_{nested_id}('{pane['id']}')">
+                    <span>{pane['title']}<br/><span id="{pane['id']}_status" class="nested-pane-status-{nested_id} {expanded_class}">(content hidden: click to show)</span></span>
                     <span id="{pane['id']}_toggle" class="nested-pane-toggle-{nested_id} {expanded_class}">▶</span>
                 </div>
                 <div id="{pane['id']}_content" class="nested-pane-content-{nested_id} {expanded_class}">
@@ -486,9 +520,9 @@ class Report(ReportInterface):
             border: 1px solid #404040;
             border-radius: 8px;
             background-color: #232323;
-            min-width: 300px;
+            min-width: 400px;
             max-width: 600px;
-            flex: 1 1 300px;
+            flex: 1 1 400px;
             display: flex;
             flex-direction: column;
             margin-bottom: 0;
@@ -513,20 +547,49 @@ class Report(ReportInterface):
             display: flex;
             align-items: center;
             justify-content: space-between;
-            transition: background-color 0.2s ease;
+            transition: background-color 0.2s ease, border-left 0.2s ease;
             font-weight: 500;
             color: #d0d0d0;
             border-radius: 8px 8px 0 0;
+            border-left: 4px solid #404040;
         }}
 
         .pane-header-{self.report_id}:hover {{
             background-color: #2d2d2d;
         }}
 
+        .pane-header-{self.report_id}.expanded {{
+            background-color: #2a2a2a;
+            color: #f0f0f0;
+            font-weight: 600;
+            border-left: 4px solid #007cba;
+        }}
+
+        .pane-header-{self.report_id}.expanded:hover {{
+            background-color: #323232;
+        }}
+
         .pane-toggle-{self.report_id} {{
             font-size: 1.2em;
             color: #a0a0a0;
-            transition: transform 0.2s ease;
+            transition: transform 0.2s ease, color 0.2s ease;
+        }}
+
+        .pane-toggle-{self.report_id}.expanded {{
+            color: #007cba;
+            font-weight: bold;
+        }}
+
+        .pane-status-{self.report_id} {{
+            font-size: 0.9em;
+            color: #888;
+            font-style: italic;
+            margin-left: 8px;
+            transition: opacity 0.2s ease;
+        }}
+
+        .pane-status-{self.report_id}.expanded {{
+            opacity: 0;
         }}
 
         .pane-content-{self.report_id} {{
@@ -569,13 +632,19 @@ class Report(ReportInterface):
         function togglePane_{self.report_id}(paneId) {{
             const content = document.getElementById(paneId + '_content');
             const toggle = document.getElementById(paneId + '_toggle');
+            const header = document.getElementById(paneId + '_header');
+            const status = document.getElementById(paneId + '_status');
 
             if (content.classList.contains('expanded')) {{
                 content.classList.remove('expanded');
                 toggle.classList.remove('expanded');
+                header.classList.remove('expanded');
+                status.classList.remove('expanded');
             }} else {{
                 content.classList.add('expanded');
                 toggle.classList.add('expanded');
+                header.classList.add('expanded');
+                status.classList.add('expanded');
             }}
         }}
 
@@ -606,8 +675,8 @@ class Report(ReportInterface):
             pane_id = pane["id"]
             panes_html += f"""
             <div class="pane-{self.report_id}" id="{pane_id}">
-                <div class="pane-header-{self.report_id}" onclick="togglePane_{self.report_id}('{pane_id}')">
-                    <span>{pane_number}{pane['title']}</span>
+                <div id="{pane_id}_header" class="pane-header-{self.report_id} {expanded_class}" onclick="togglePane_{self.report_id}('{pane_id}')">
+                    <span>{pane_number}{pane['title']}<br/><span id="{pane_id}_status" class="pane-status-{self.report_id} {expanded_class}">(content hidden: click to show)</span></span>
                     <span>
                         <button type=\"button\" class=\"expand-btn-{self.report_id}\" id=\"{pane_id}_expandbtn\" onclick=\"event.stopPropagation();expandPaneFullWidth_{self.report_id}('{pane_id}')\">Expand</button>
                         <span id="{pane_id}_toggle" class="pane-toggle-{self.report_id} {expanded_class}">▶</span>


### PR DESCRIPTION

Scipy2025 slides are based on https://github.com/sklam/numba-prototypes/tree/enh/scipy_2025

This PR adopted the rendering changes to improve presentation of the notebooks.

Main changes:

- Report panes now have timing and rendering overhead info.
- They now have tip text indicating the pane is collapsed and hidden.
- Benchmarks are now displayed with matplotlib.
